### PR TITLE
Add extra configuration to publish http port

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repo aims to create a one-stop script which would allow the setup of a MERN
 - docker-compose
 - wget
 
+Tested working with Ubuntu 20.04
+
 # Setup
 
 ```bash
@@ -27,10 +29,12 @@ Note: Ignore `Git repo not initialized Error: Command failed: git --version` whe
 ## Production
 
 ```bash
-$ docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+$ docker-compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.http.yml up -d --build
 ```
 
-Add `-f docker-compose.ssl.yml` for SSL setup
+Add `-f docker-compose.ssl.yml` for SSL setup and remove `-f docker-compose.http.yml`.
+
+_TIP_: Make a bash file that runs the above for you. This functionality will be added later.
 
 ## Development
 

--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -1,0 +1,5 @@
+version: "3.3"
+services:
+  nginx:
+    ports:
+      - "80:80"


### PR DESCRIPTION
Due to testing in an SSL environment, I forgot to add the docker-compose file to publish port HTTP 80.

A future feature could be to allow users to add their `conf` files and `ssl` files into the `nginx` folder.